### PR TITLE
Clean up after GMP's random number generator in 'free_GF()' function.

### DIFF
--- a/gfp2.c
+++ b/gfp2.c
@@ -95,6 +95,7 @@ void free_GF(GF_params* field) {
     for (i = 0 ; i < GF_TMP_REGS ; i++)
       clear_GF(&field->GFtmp[i]);
     mpz_clear(field->p); mpz_clear(field->tmp1); mpz_clear(field->tmp2); mpz_clear(field->tmp3);
+    gmp_randclear(field->state);
     field->initialized = 0;
   }
 }


### PR DESCRIPTION
RNG gets initialized in 'setup_GF()', so 'free_GF()' must clean up after it.

You can see that without the proposed patch RNG is not cleared by using Valgrind on the following example:

``` c
int main(void)
{
    GF_params field;
    setup_GF(&field, "238047");

    free_GF(&field);
}
```

Here's the Valgrind's output:

```
$ valgrind --leak-check=full --show-leak-kinds=all ./gfp2_test 
==7460== Memcheck, a memory error detector
==7460== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==7460== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==7460== Command: ./gfp2_test
==7460== 
==7460== 
==7460== HEAP SUMMARY:
==7460==     in use at exit: 2,504 bytes in 1 blocks
==7460==   total heap usage: 24 allocs, 23 frees, 2,696 bytes allocated
==7460== 
==7460== 2,504 bytes in 1 blocks are definitely lost in loss record 1 of 1
==7460==    at 0x4C28BF6: malloc (vg_replace_malloc.c:299)
==7460==    by 0x4E417B8: __gmp_default_allocate (memory.c:54)
==7460==    by 0x4E93DFC: __gmp_randinit_mt_noseed (randmt.c:407)
==7460==    by 0x4E94088: __gmp_randinit_mt (randmts.c:163)
==7460==    by 0x4010DB: setup_GF (gfp2.c:82)
==7460==    by 0x40701E: main (gfp2_test.c:9)
==7460== 
==7460== LEAK SUMMARY:
==7460==    definitely lost: 2,504 bytes in 1 blocks
==7460==    indirectly lost: 0 bytes in 0 blocks
==7460==      possibly lost: 0 bytes in 0 blocks
==7460==    still reachable: 0 bytes in 0 blocks
==7460==         suppressed: 0 bytes in 0 blocks
==7460== 
==7460== For counts of detected and suppressed errors, rerun with: -v
==7460== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
